### PR TITLE
Remove redundant InputSection prop and clean up imports

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -269,7 +269,7 @@ export default function Home() {
               AI-Powered RSOC Content Page Creator
             </p>
             <p className="text-lg opacity-75 mt-2">
-              Create articles fully compliant with Google's policies in minutes
+              Create articles fully compliant with Google&apos;s policies in minutes
             </p>
           </div>
         </div>

--- a/components/InputSection.tsx
+++ b/components/InputSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Sparkles, RotateCcw, Upload, Image, Loader2 } from 'lucide-react';
+import { Sparkles, RotateCcw, Upload, Loader2 } from 'lucide-react';
 import { AppState } from '@/types/app';
 
 interface InputSectionProps {
@@ -9,7 +9,6 @@ interface InputSectionProps {
   updateState: (updates: Partial<AppState>) => void;
   onGetSuggestions: () => void;
   onClearInput: () => void;
-  onImageUpload: (file: File) => void;
   onImageUpload: (file: File) => void;
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate `onImageUpload` prop declaration
- drop unused `Image` icon import
- escape apostrophe in homepage header to satisfy eslint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bab0116a8c8327966cb347f6d67b34