### PR TITLE
feat: add creative context to app state

### DIFF
--- a/types/app.ts
+++ b/types/app.ts
@@ -25,6 +25,20 @@ export interface AppState {
   showSuggestions: boolean;
   article: Article | null;
   articleHistory: Article[];
+  creativeContext?: {
+    marketingHooks?: string[];
+    suggestedStructure?: Array<{ title: string; content: string }>;
+    emotionalTriggers?: string[];
+    targetAudience?: string;
+    uniqueSellingPoints?: string[];
+    businessVertical?: string;
+    keyThemes?: string[];
+    extractedKeywords?: {
+      primary: string;
+      secondary: string[];
+      longTail: string[];
+    };
+  };
 }
 
 export interface SuggestionResponse {


### PR DESCRIPTION
## Summary
- extend `AppState` with optional `creativeContext` field to capture marketing hooks, structure, audience, and keyword details

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bac0f95a1883278f11c1f720738f49