### PR TITLE
feat: enhance subheading guidelines

### DIFF
--- a/app/api/generate-article/route.ts
+++ b/app/api/generate-article/route.ts
@@ -254,6 +254,24 @@ CREATIVE CONTEXT:
 
 STRUCTURE GUIDANCE FROM CREATIVE:
 ${creativeContext.suggestedStructure?.map(s => `- ${s.title}`).join('\n')}
+
+MANDATORY STRUCTURE:
+
+H2 SUBHEADING REQUIREMENTS:
+For each required section, create engaging H2 headings that:
+- Include the primary keyword naturally (in at least 2 headings)
+- Reflect the specific benefit or problem addressed in that section
+- Avoid generic phrases like 'Your Guide to' or 'Overview'
+- Use action words and specific outcomes
+
+Templates based on section type:
+- Year ranges: '[Primary Keyword] [Year]: [Specific Problem/Benefit]'
+- Product types: '[Primary Keyword] for [Type]: [Unique Value Proposition]'
+- Numbered items: '[Number]. [Specific Action/Check] for [Primary Keyword]'
+
+Example transformations:
+BAD: 'Hatchbacks: Your Guide to Affordable Cars'
+GOOD: 'Used Car EMI for Hatchbacks: Maximum Savings, Minimum Space'
 ` : ''}
 
       SEO SPECIFICATIONS:


### PR DESCRIPTION
## Summary
- define mandatory H2 subheading rules for generated articles
- provide templates and examples for year ranges, product types, and numbered items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd97f35d9c8327b5eb0fc124fa1447