### PR TITLE
refactor: extract year and segment parsing

### DIFF
--- a/lib/extractYearSegments.ts
+++ b/lib/extractYearSegments.ts
@@ -1,0 +1,40 @@
+interface SuggestedSection {
+  title: string;
+  content: string;
+}
+
+export function extractYearSegments(
+  suggestedStructure?: SuggestedSection[]
+): { yearRanges: string[]; productSegments: string[] } {
+  const yearRangePattern = /((?:19|20)\d{2})\s*-\s*(\d{2}|\d{4})/g;
+  const yearRanges: string[] = [];
+  const productSegments: string[] = [];
+
+  if (suggestedStructure) {
+    suggestedStructure.forEach(section => {
+      yearRangePattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      let foundYear = false;
+      while ((match = yearRangePattern.exec(section.title)) !== null) {
+        foundYear = true;
+        const start = match[1];
+        const end = match[2].length === 2 ? start.slice(0, 2) + match[2] : match[2];
+        yearRanges.push(`${start}-${end}`);
+      }
+      if (!foundYear) {
+        const segment = section.title
+          .replace(yearRangePattern, '')
+          .replace(/models?/i, '')
+          .trim();
+        if (segment) productSegments.push(segment);
+      }
+    });
+  }
+
+  return {
+    yearRanges: Array.from(new Set(yearRanges)),
+    productSegments: Array.from(new Set(productSegments))
+  };
+}
+
+export type { SuggestedSection };


### PR DESCRIPTION
## Summary
- add `extractYearSegments` utility to parse year ranges and product segments from suggested structure
- reuse helper in `mockGeminiSuggestionsWithContext` and `getGeminiSuggestionsWithContext`
- wire up helper import and types in `get-suggestions` route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be4fc5dbcc8327822b4eb1017bd792