### PR TITLE
Fix headline refinement without colon

### DIFF
--- a/__tests__/refineHeadlinesWithNewKeyword.test.ts
+++ b/__tests__/refineHeadlinesWithNewKeyword.test.ts
@@ -13,4 +13,10 @@ describe('refineHeadlinesWithNewKeyword', () => {
     const result = await refineHeadlinesWithNewKeyword(headlines, 'NewKey');
     expect(result).toEqual(['NewKey: The quick brown fox']);
   });
+
+  it('returns original headline if keyword already exists without colon', async () => {
+    const headlines = ['NewKey and the quick brown fox'];
+    const result = await refineHeadlinesWithNewKeyword(headlines, 'NewKey');
+    expect(result).toEqual(['NewKey and the quick brown fox']);
+  });
 });

--- a/app/api/get-suggestions/route.ts
+++ b/app/api/get-suggestions/route.ts
@@ -279,13 +279,19 @@ ${additionalRequirements}
 export async function refineHeadlinesWithNewKeyword(headlines: string[], newKeyword: string) {
   // This function will refine existing headlines based on a new keyword
   return headlines.map((headline) => {
-    if (headline.includes(":")) {
-      const refinedText = headline.split(":")[1].trim();
-      return `${newKeyword}: ${refinedText}`;
+    const trimmedHeadline = headline.trim();
+
+    // Only split when a colon exists in the headline
+    if (!trimmedHeadline.includes(':')) {
+      // If the headline already contains the new keyword, leave it unchanged
+      return trimmedHeadline.toLowerCase().includes(newKeyword.toLowerCase())
+        ? trimmedHeadline
+        : `${newKeyword}: ${trimmedHeadline}`;
     }
 
-    // Gracefully handle headlines without a colon by prepending the new keyword
-    return `${newKeyword}: ${headline.trim()}`;
+    const [, ...rest] = trimmedHeadline.split(':');
+    const refinedText = rest.join(':').trim();
+    return `${newKeyword}: ${refinedText}`;
   });
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath, URL } from 'url';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- Safely handle headlines lacking a colon when refining keywords
- Configure Vitest to resolve `@` path alias
- Expand tests for headlines with and without colons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be5392e2c083279dbfa3ca3d6f2e89