### PR TITLE
feat: allow natural context-aware headlines

### DIFF
--- a/__tests__/refineHeadlinesWithNewKeyword.test.ts
+++ b/__tests__/refineHeadlinesWithNewKeyword.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { refineHeadlinesWithNewKeyword } from '../app/api/get-suggestions/route';
 
 describe('refineHeadlinesWithNewKeyword', () => {
-  it('replaces existing keyword when colon is present', async () => {
+  it('replaces existing keyword and removes colon when present', async () => {
     const headlines = ['OldKey: The quick brown fox'];
     const result = await refineHeadlinesWithNewKeyword(headlines, 'NewKey');
-    expect(result).toEqual(['NewKey: The quick brown fox']);
+    expect(result).toEqual(['NewKey The quick brown fox']);
   });
 
   it('prepends keyword when no colon is present', async () => {
     const headlines = ['The quick brown fox'];
     const result = await refineHeadlinesWithNewKeyword(headlines, 'NewKey');
-    expect(result).toEqual(['NewKey: The quick brown fox']);
+    expect(result).toEqual(['NewKey The quick brown fox']);
   });
 
   it('returns original headline if keyword already exists without colon', async () => {


### PR DESCRIPTION
## Summary
- remove forced `keyword:` prefix in headline prompt and refine logic
- enforce urgent hooks and year ranges in headline generation
- update tests for new headline rules

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c013f183d48327ba0d995a2980555f